### PR TITLE
Primitive matching

### DIFF
--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -39,10 +39,6 @@
 ; emits (list ir identifier (hash base locals globals closures)
 
 (define (expression-to-ir code ctx)
-  (display "Expr: ")
-  (display code)
-  (display "\n")
-
   (cond
     [(list? code)
      (case (first code) [(lambda) (lambda-to-ir code ctx)]
@@ -101,7 +97,7 @@
 (define (match-let-to-ir code ir ctx)
   (if (= (length (second code)) 0)
     (let ([body (expression-to-ir (third code) ctx)])
-      (list (append (first body) ir) (second body) (third ir)))
+      (list (append (first body) ir) (second body) (third body)))
     (let* ([expression (expression-to-ir (second (first (second code))) ctx)]
            [result (match-ir (first (first (second code)))
                              (second expression)
@@ -186,8 +182,6 @@
                                                               'globals globals
                                                               'base 0
                                                               'lambdas lambdas))])
-        (pretty-print expression)
-        (display "\n")
         (program-to-ir (rest sexpr)
                        (cons (first expression) ir) 
                        (hash-ref (third expression) 'globals)

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -119,6 +119,7 @@
 
 (define (match-symbol-ir pattern needle ir load? ctx)
   (let ([sanity (expression-to-ir (list 'symbol? needle) ctx)])
+    
     (display "Sanity: ")
     (display sanity)
     (display "\n")))
@@ -131,9 +132,9 @@
                                (list 'length needle) 
                                (- (length pattern) 1)))
                    ctx)])
-    (match-list-body-ir (rest pattern) needle ir load? ctx sanity)))
+    (match-list-body-ir (rest pattern) needle (append sanity ir) load? ctx)))
 
-(define (match-list-body-ir pattern needle ir load? ctx sanity)
+(define (match-list-body-ir pattern needle ir load? ctx)
   (if (= (length pattern) 0)
     (list ir ctx)
     (let ([current-match
@@ -149,10 +150,9 @@
                           (cons (list "="
                                       (hash-ref ctx 'base) 
                                       list "call" "rest" needle)
-                                (append (first current-match ir)))
+                                (append (first current-match) ir))
                           load?
-                          (second current-match)
-                          sanity))))
+                          (second current-match)))))
 
 (define (call-to-ir code ctx)
   (match-let ([(list ir emission identifiers nctx)

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -39,13 +39,17 @@
 ; emits (list ir identifier (hash base locals globals closures)
 
 (define (expression-to-ir code ctx)
+  (display "Expr: ")
+  (display code)
+  (display "\n")
+
   (cond
     [(list? code)
      (case (first code) [(lambda) (lambda-to-ir code ctx)]
                         [(define) (define-to-ir code ctx)]
                         [(quote) (quote-to-ir (second code) ctx)]
                         [(let) (let-to-ir code '() ctx)]
-                        ([(match-let) (match-let-to-ir code '() ctx)]
+                        [(match-let) (match-let-to-ir code '() ctx)]
                         [else (call-to-ir code ctx)])]
     [(number? code)
      (list '() (list "imm" code) ctx)]
@@ -94,7 +98,9 @@
                            (cons (first (first (second code)))
                                  (hash-ref (third value) 'locals)))))))
 
-(define (match-let-ir code ir ctx)
+(define (match-let-to-ir code ir ctx)
+  (display code)
+  (display "\n")
   (if (= (length (second code)) 0)
     (let ([body (expression-to-ir (third code) ctx)])
       (list (append (first body) ir) (second body) (third ir)))
@@ -104,13 +110,18 @@
                              '()
                              #t
                              (third expression))])
-      (match-let-ir (list "match-let" (rest (second code)) (third code))
+      (match-let-to-ir (list "match-let" (rest (second code)) (third code))
                     (append (first result) ir)
                     (second result)))))
 
 (define (match-ir pattern needle ir load? ctx)
+  (display "Match: ")
+  (display (symbol? pattern))
+  (display "\n")
+
   (cond [(symbol? pattern) (match-symbol-ir pattern needle ir load? ctx)]
-        [(list pattern) (match-list-ir pattern needle ir load? ctx)]))
+        [(list? pattern) (match-list-ir pattern needle ir load? ctx)]
+        [else (display "Ahhh!!! Unknown match target\n")]))
 
 ; identifier is a boolean
 
@@ -121,6 +132,13 @@
 
 (define (match-symbol-ir pattern needle ir load? ctx)
   (let ([sanity (ensure-type needle "symbol" ctx)])
+    (display "Sanity: ")
+    (display sanity)
+    (display "\n")))
+
+(define (match-list-ir pattern needle ir load? ctx)
+  (let ([sanity (ensure-type needle "list" ctx)])
+    (display "Sanity: ")
     (display sanity)
     (display "\n")))
 

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -119,8 +119,10 @@
 
 (define (match-symbol-ir pattern needle ir load? ctx)
   (let ([sanity (expression-to-ir (list 'symbol? needle) ctx)])
-    (list (cons (list "=" pattern needle) (append sanity ir))
-          (hash-set ctx 'locals (cons pattern (hash-ref ctx 'locals))))))
+    (list (cons (list "=" pattern needle) (append (first sanity) ir))
+          (hash-set (third sanity)
+                    'locals
+                    (cons pattern (hash-ref (third sanity) 'locals))))))
 
 (define (match-list-ir pattern needle ir load? ctx)
   (let* ([sanity (expression-to-ir

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -130,7 +130,11 @@
                                (list 'length needle) 
                                (- (length pattern) 1)))
                    ctx)])
-    (match-list-body-ir (rest pattern) needle (append sanity ir) load? (third sanity))))
+    (match-list-body-ir (rest pattern)
+                        needle
+                        (append (first sanity) ir)
+                        load?
+                        (third sanity))))
 
 (define (match-list-body-ir pattern needle ir load? ctx)
   (if (= (length pattern) 0)
@@ -148,7 +152,7 @@
                           (list "local" (hash-ref nctx 'base))
                           (cons (list "="
                                       (hash-ref nctx 'base) 
-                                      list "call" "rest" needle)
+                                      (list "call" "rest" needle))
                                 (first current-match))
                           load?
                           nctx))))

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -123,21 +123,20 @@
         [(list? pattern) (match-list-ir pattern needle ir load? ctx)]
         [else (display "Ahhh!!! Unknown match target\n")]))
 
-; identifier is a boolean
-
-(define (ensure-type identifier target ctx)
-  (list (list "=" (hash-ref ctx 'base) (list "type?" identifier target))
-        (list "local" (hash-ref ctx 'base))
-        (hash-set ctx 'base (+ (hash-ref ctx 'base) 1))))
-
 (define (match-symbol-ir pattern needle ir load? ctx)
-  (let ([sanity (ensure-type needle "symbol" ctx)])
+  (let ([sanity (expression-to-ir (list 'symbol? needle) ctx)])
     (display "Sanity: ")
     (display sanity)
     (display "\n")))
 
 (define (match-list-ir pattern needle ir load? ctx)
-  (let ([sanity (ensure-type needle "list" ctx)])
+  (let* ([sanity (expression-to-ir
+                   (list 'and 
+                         (list 'list? needle)
+                         (list '= 
+                               (list 'length needle) 
+                               (- (length pattern) 1)))
+                   ctx)])
     (display "Sanity: ")
     (display sanity)
     (display "\n")))

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -153,7 +153,7 @@
                                       (list "call" "rest" needle))
                                 (first current-match))
                           load?
-                          nctx))))
+                          (hash-set nctx 'base (+ (hash-ref nctx 'base) 1))))))
 
 (define (call-to-ir code ctx)
   (match-let ([(list ir emission identifiers nctx)

--- a/compiler/compiler.rkt
+++ b/compiler/compiler.rkt
@@ -39,10 +39,6 @@
 ; emits (list ir identifier (hash base locals globals closures)
 
 (define (expression-to-ir code ctx)
-  (display "Expr: ")
-  (display code)
-  (display "\n")
-
   (cond
     [(list? code)
      (case (first code) [(lambda) (lambda-to-ir code ctx)]
@@ -99,8 +95,6 @@
                                  (hash-ref (third value) 'locals)))))))
 
 (define (match-let-to-ir code ir ctx)
-  (display code)
-  (display "\n")
   (if (= (length (second code)) 0)
     (let ([body (expression-to-ir (third code) ctx)])
       (list (append (first body) ir) (second body) (third ir)))
@@ -111,14 +105,10 @@
                              #t
                              (third expression))])
       (match-let-to-ir (list "match-let" (rest (second code)) (third code))
-                    (append (first result) ir)
-                    (second result)))))
+                       (append (first result) ir)
+                       (second result)))))
 
 (define (match-ir pattern needle ir load? ctx)
-  (display "Match: ")
-  (display (symbol? pattern))
-  (display "\n")
-
   (cond [(symbol? pattern) (match-symbol-ir pattern needle ir load? ctx)]
         [(list? pattern) (match-list-ir pattern needle ir load? ctx)]
         [else (display "Ahhh!!! Unknown match target\n")]))
@@ -137,9 +127,7 @@
                                (list 'length needle) 
                                (- (length pattern) 1)))
                    ctx)])
-    (display "Sanity: ")
-    (display sanity)
-    (display "\n")))
+    (list (first sanity) (third sanity))))
 
 (define (call-to-ir code ctx)
   (match-let ([(list ir emission identifiers nctx)


### PR DESCRIPTION
This can be barely be considered a `match` implementation, but it should be enough to bootstrap (unpacking lists).